### PR TITLE
fix: visual skeleton for list

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,6 +45,7 @@ export class AppComponent implements OnInit {
       .subscribe(/* unsubscribed by `first()` */);
   }
 
+  // TODO fix: on quick pagination page change the previous loading state of this.loadPokemons(); should be destroyed (http request interrupted, subscribe callback should never happen)
   onPageChange(event: PageEvent) {
     this.offset = event.pageIndex * event.pageSize;
     this.limit = event.pageSize;

--- a/src/app/pokemon-cards/pokemon-list.component.css
+++ b/src/app/pokemon-cards/pokemon-list.component.css
@@ -19,6 +19,7 @@
 .singlePokemonImage {
   width: 100%;
   height: 100px;
+  min-width: 100px;
   transition: transform 0.3s;
 }
 


### PR DESCRIPTION
make images in list take always their designated space so they are not "jumping" and "rozpychajing"